### PR TITLE
update version for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sic-classification-library"
-version = "0.1.3"
+version = "0.1.4"
 description = "Standard Industrial Classification library"
 authors = ["Steve Gibbard <steve.gibbard@ons.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
# Release v0.1.4 — example rephrase CSV columns

## Summary

Release **v0.1.4** so the packaged `example_rephrased_sic_data.csv` has `rephrased_description` instead of `reviewed_description` (fix already on `main`).

## Changes

- Bump version to **0.1.4** in `pyproject.toml`
- Tag **v0.1.4**

## How to test

```bash
git show v0.1.4:src/industrial_classification/data/example_rephrased_sic_data.csv | head -1
```

Expected header: `input_code,sic_code,input_description,rephrased_description` (stays on your current branch)
